### PR TITLE
[WIP] Introducing session reminders

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     package="com.gdgnantes.devfest.android">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <application
         android:name=".ScheduleApplication"
@@ -66,6 +67,15 @@
             android:name="com.gdgnantes.devfest.android.provider.ScheduleProvider"
             android:authorities="${applicationId}.provider.schedule"
             android:exported="false" />
+
+        <receiver
+            android:name=".content.RemindersReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.TIME_SET" />
+            </intent-filter>
+        </receiver>
 
         <meta-data
             android:name="preloaded_fonts"

--- a/app/src/main/kotlin/com/gdgnantes/devfest/android/ScheduleApplication.kt
+++ b/app/src/main/kotlin/com/gdgnantes/devfest/android/ScheduleApplication.kt
@@ -7,14 +7,11 @@ import android.os.Build
 import android.support.annotation.RequiresApi
 import android.support.v4.content.ContextCompat
 import android.support.v7.app.AppCompatDelegate
+import com.gdgnantes.devfest.android.content.RemindersManager
 import com.gdgnantes.devfest.android.util.BuildUtils
 
 
 class ScheduleApplication : Application() {
-
-    companion object {
-        private const val CHANNEL_REMINDERS = "channel:reminders"
-    }
 
     init {
         AppCompatDelegate.setCompatVectorFromResourcesEnabled(true)
@@ -29,7 +26,7 @@ class ScheduleApplication : Application() {
 
     @RequiresApi(Build.VERSION_CODES.O)
     private fun createNotificationChannels() {
-        val channel = NotificationChannel(CHANNEL_REMINDERS,
+        val channel = NotificationChannel(RemindersManager.CHANNEL_REMINDERS,
                 getString(R.string.reminders_channel_name),
                 NotificationManager.IMPORTANCE_HIGH).apply {
             description = getString(R.string.reminders_channel_description)

--- a/app/src/main/kotlin/com/gdgnantes/devfest/android/ScheduleApplication.kt
+++ b/app/src/main/kotlin/com/gdgnantes/devfest/android/ScheduleApplication.kt
@@ -1,12 +1,44 @@
 package com.gdgnantes.devfest.android
 
 import android.app.Application
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.os.Build
+import android.support.annotation.RequiresApi
+import android.support.v4.content.ContextCompat
 import android.support.v7.app.AppCompatDelegate
+import com.gdgnantes.devfest.android.util.BuildUtils
+
 
 class ScheduleApplication : Application() {
 
+    companion object {
+        private const val CHANNEL_REMINDERS = "channel:reminders"
+    }
+
     init {
         AppCompatDelegate.setCompatVectorFromResourcesEnabled(true)
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        if (BuildUtils.hasO()) {
+            createNotificationChannels()
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private fun createNotificationChannels() {
+        val channel = NotificationChannel(CHANNEL_REMINDERS,
+                getString(R.string.reminders_channel_name),
+                NotificationManager.IMPORTANCE_HIGH).apply {
+            description = getString(R.string.reminders_channel_description)
+            enableLights(true)
+            lightColor = ContextCompat.getColor(this@ScheduleApplication, R.color.candy)
+            enableVibration(true)
+            vibrationPattern = longArrayOf(500, 500, 500, 500)
+        }
+        getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
     }
 
 }

--- a/app/src/main/kotlin/com/gdgnantes/devfest/android/SessionActivity.kt
+++ b/app/src/main/kotlin/com/gdgnantes/devfest/android/SessionActivity.kt
@@ -2,11 +2,11 @@ package com.gdgnantes.devfest.android
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.support.v7.app.ActionBar
 import android.widget.TextSwitcher
 import com.gdgnantes.devfest.android.app.BaseActivity
-import com.gdgnantes.devfest.android.app.PREFIX_EXTRA
 
 
 class SessionActivity : BaseActivity() {
@@ -14,10 +14,8 @@ class SessionActivity : BaseActivity() {
     companion object {
         private val FRAGMENT_SESSION_DETAIL = "fragment:sessionDetails"
 
-        private val EXTRA_SESSION_ID = "$PREFIX_EXTRA.sessionDetails"
-
-        fun newIntent(context: Context, sessionId: String): Intent
-                = Intent(context, SessionActivity::class.java).putExtra(EXTRA_SESSION_ID, sessionId)
+        fun newIntent(context: Context, sessionId: String): Intent = Intent(context, SessionActivity::class.java)
+                .setData(Uri.parse("content://sessions/$sessionId"))
     }
 
     private lateinit var switcher: TextSwitcher
@@ -61,7 +59,7 @@ class SessionActivity : BaseActivity() {
                 }
             }
         }
-        return intent.getStringExtra(EXTRA_SESSION_ID)
+        return intent.data.lastPathSegment
     }
 
 }

--- a/app/src/main/kotlin/com/gdgnantes/devfest/android/content/RemindersManager.kt
+++ b/app/src/main/kotlin/com/gdgnantes/devfest/android/content/RemindersManager.kt
@@ -1,0 +1,140 @@
+package com.gdgnantes.devfest.android.content
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.os.Bundle
+import android.support.v4.app.NotificationCompat
+import android.support.v4.app.NotificationManagerCompat
+import android.support.v4.content.ContextCompat
+import android.util.Log
+import com.gdgnantes.devfest.android.BookmarkManager
+import com.gdgnantes.devfest.android.R
+import com.gdgnantes.devfest.android.SessionActivity
+import com.gdgnantes.devfest.android.database.sqlIn
+import com.gdgnantes.devfest.android.format.text.DateTimeFormatter
+import com.gdgnantes.devfest.android.model.toRoom
+import com.gdgnantes.devfest.android.model.toSession
+import com.gdgnantes.devfest.android.provider.ScheduleContract
+import java.util.*
+
+class RemindersManager private constructor(private val context: Context) {
+
+    // NOTE Cyril
+    // The current implementation of the reminders consists on
+    // setting on alarm (in the AlarmManager) that will be triggered
+    // exactly REMINDER_ANTICIPATION milliseconds before the next
+    // (in time) bookmarked event. The alarm's PendingIntent
+    // contains all of the information of the next bookmarked events.
+    // Note that it's event*s* because, although it should be quite
+    // rare, there may be several bookmarked events at the same
+    // time.
+    //
+    // Once triggered, the alarm will display a notification on a
+    // per-event basis. In case multiple bookmarked event start at
+    // the same time, the system will hence trigger several
+    // notifications at the same time.
+
+    companion object {
+        const val CHANNEL_REMINDERS = "channel:reminders"
+
+        private const val TAG = "RemindersManager"
+
+        private const val KEY_ID = "key:id"
+        private const val KEY_TITLE = "key:title"
+        private const val KEY_TEXT = "key:text"
+
+        private const val NOTIFICATION_ID = 666
+
+        private const val REMINDER_ANTICIPATION = 5 * 60 * 1000L // 5 minutes
+
+        private var instance: RemindersManager? = null
+
+        fun from(context: Context): RemindersManager {
+            synchronized(RemindersManager::class) {
+                if (instance == null) {
+                    instance = RemindersManager(context.applicationContext)
+                }
+                return instance!!
+            }
+        }
+    }
+
+    fun updateAlarm() {
+        val bookmarkIds = BookmarkManager.from(context).getLiveData().value ?: emptySet()
+
+        val cursor = context.contentResolver.query(
+                ScheduleContract.Sessions.CONTENT_URI,
+                null,
+                "${sqlIn(ScheduleContract.Sessions.SESSION_ID, bookmarkIds)} AND " +
+                        "${ScheduleContract.Sessions.SESSION_START_TIMESTAMP} > strftime('%s', 'now') + ${REMINDER_ANTICIPATION / 1000}",
+                null,
+                "${ScheduleContract.Sessions.SESSION_START_TIMESTAMP} ASC")
+
+        var nextAlarm: Date? = null
+
+        val reminderInfos = mutableListOf<Bundle>()
+        if (cursor != null) {
+            while (cursor.moveToNext()) {
+                val session = cursor.toSession()
+                val room = cursor.toRoom()
+
+                if (nextAlarm != null && nextAlarm != session.startTimestamp) {
+                    break
+                }
+                nextAlarm = session.startTimestamp
+
+                val reminderInfo = Bundle().apply {
+                    putString(KEY_ID, session.id)
+                    putString(KEY_TITLE, session.title)
+                    putString(KEY_TEXT, context.getString(R.string.reminders_text, DateTimeFormatter.formatHHmm(session.startTimestamp), room.name))
+                }
+                reminderInfos.add(reminderInfo)
+            }
+            cursor.close()
+        }
+
+        val pendingIntent = PendingIntent.getBroadcast(context, 0,
+                RemindersReceiver.newShowRemindersIntent(context, reminderInfos), PendingIntent.FLAG_UPDATE_CURRENT)
+
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        alarmManager.cancel(pendingIntent)
+
+        if (nextAlarm != null) {
+            val actualAlarm = Date(nextAlarm.time - REMINDER_ANTICIPATION)
+            Log.d(TAG, "Scheduling alarm: ${DateTimeFormatter.formatEEEEMMMMd(actualAlarm)} ${DateTimeFormatter.formatHHmm(actualAlarm)}")
+            alarmManager.setExact(AlarmManager.RTC_WAKEUP, actualAlarm.time, pendingIntent)
+        } else {
+            Log.d(TAG, "Removing alarms")
+        }
+    }
+
+    fun showNotification(reminderInfos: List<Bundle>) {
+        reminderInfos.forEach {
+            val id = it.getString(KEY_ID)
+            val title = it.getString(KEY_TITLE)
+            val text = it.getString(KEY_TEXT)
+
+            val pendingIntent = PendingIntent.getActivity(context, 0,
+                    SessionActivity.newIntent(context, id), 0)
+
+            val notification = NotificationCompat.Builder(context, CHANNEL_REMINDERS)
+                    .setAutoCancel(true)
+                    .setCategory(NotificationCompat.CATEGORY_EVENT)
+                    .setColor(ContextCompat.getColor(context, R.color.candy))
+                    .setDefaults(NotificationCompat.DEFAULT_ALL)
+                    .setShowWhen(false)
+                    .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+                    .setSmallIcon(R.drawable.ic_status_devfest)
+                    .setTicker(title)
+                    .setContentTitle(title)
+                    .setContentText(text)
+                    .setContentIntent(pendingIntent)
+                    .build()
+
+            NotificationManagerCompat.from(context)
+                    .notify(id, NOTIFICATION_ID, notification)
+        }
+    }
+
+}

--- a/app/src/main/kotlin/com/gdgnantes/devfest/android/content/RemindersReceiver.kt
+++ b/app/src/main/kotlin/com/gdgnantes/devfest/android/content/RemindersReceiver.kt
@@ -1,0 +1,52 @@
+package com.gdgnantes.devfest.android.content
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.os.PowerManager
+import com.gdgnantes.devfest.android.app.PREFIX_ACTION
+import com.gdgnantes.devfest.android.app.PREFIX_EXTRA
+import com.gdgnantes.devfest.android.util.asArrayList
+
+class RemindersReceiver : BroadcastReceiver() {
+
+    companion object {
+        private const val ACTION_SHOW_REMINDERS = "${PREFIX_ACTION}SHOW_REMINDERS"
+
+        private const val EXTRA_REMINDER_INFOS = "${PREFIX_EXTRA}REMINDER_INFOS"
+
+        private const val WAKE_LOCK_LIFE_TIME = 30 * 1000L
+
+        fun newShowRemindersIntent(context: Context, reminderInfos: List<Bundle>): Intent
+                = Intent(context, RemindersReceiver::class.java)
+                .setAction(ACTION_SHOW_REMINDERS)
+                .putParcelableArrayListExtra(EXTRA_REMINDER_INFOS, reminderInfos.asArrayList())
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val wakeLock = acquireWakeLock(context)
+        val result = goAsync()
+        Thread({
+            val manager = RemindersManager.from(context)
+            when (intent.action) {
+                ACTION_SHOW_REMINDERS -> {
+                    manager.showNotification(intent.getParcelableArrayListExtra<Bundle>(EXTRA_REMINDER_INFOS))
+                }
+            }
+            manager.updateAlarm()
+
+            wakeLock.release()
+            result.finish()
+        }).start()
+    }
+
+    private fun acquireWakeLock(context: Context): PowerManager.WakeLock {
+        val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+        return powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "devfest-wake-lock").apply {
+            setReferenceCounted(false)
+            acquire(WAKE_LOCK_LIFE_TIME)
+        }
+    }
+
+}

--- a/app/src/main/kotlin/com/gdgnantes/devfest/android/database/DatabaseUtils.kt
+++ b/app/src/main/kotlin/com/gdgnantes/devfest/android/database/DatabaseUtils.kt
@@ -1,0 +1,14 @@
+package com.gdgnantes.devfest.android.database
+
+fun sqlIn(expr: String, inElements: Collection<String>, negative: Boolean = false): String {
+    if (inElements.isEmpty()) {
+        // SQLite doesn't allow the in clause to be empty.
+        // Let's deal with that by considering it is never possible
+        // to be "in an empty set".
+        return if (negative) "1" else "0"
+    }
+    return inElements.joinToString(
+            separator = ", ",
+            prefix = if (negative) "$expr NOT IN (" else "$expr IN(",
+            postfix = ")") { android.database.DatabaseUtils.sqlEscapeString(it) }
+}

--- a/app/src/main/kotlin/com/gdgnantes/devfest/android/util/BuildUtils.kt
+++ b/app/src/main/kotlin/com/gdgnantes/devfest/android/util/BuildUtils.kt
@@ -1,0 +1,9 @@
+package com.gdgnantes.devfest.android.util
+
+import android.os.Build
+
+object BuildUtils {
+
+    fun hasO() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+
+}

--- a/app/src/main/kotlin/com/gdgnantes/devfest/android/util/CollectionExtensions.kt
+++ b/app/src/main/kotlin/com/gdgnantes/devfest/android/util/CollectionExtensions.kt
@@ -1,0 +1,3 @@
+package com.gdgnantes.devfest.android.util
+
+fun <T> List<T>.asArrayList() = if (this is ArrayList) this else ArrayList(this)

--- a/app/src/main/res/drawable-anydpi/ic_status_devfest.xml
+++ b/app/src/main/res/drawable-anydpi/ic_status_devfest.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportHeight="24"
+    android:viewportWidth="24">
+    <path
+        android:fillColor="#ffffff"
+        android:pathData="M11.045 1c0.594 0 1.32 0.418 1.628 0.924l5.5 9.163c0.14 0.229 0.216 0.524 0.229 0.825 0.016 0.362 -0.06 0.734 -0.228 1.01l-0.001 0.002 -5.5 9.163C12.365 22.593 11.639 23 11.045 23l-4.796 0c-0.594 0 -0.825 -0.407 -0.517 -0.913 0 0 3.914 -6.497 5.457 -9.06 0.379 -0.628 0.379 -1.415 0 -2.043C9.646 8.421 5.732 1.924 5.732 1.924 5.424 1.418 5.655 1 6.249 1l4.796 0z"
+        android:strokeLineJoin="round"
+        android:strokeMiterLimit="1.41421" />
+</vector>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -44,4 +44,7 @@
     <string name="type_quicky">Quicky</string>
     <string name="type_talk">Talk</string>
 
+    <string name="reminders_channel_description">Reminders display a notification 5 minutes before the start of one of your bookmarked session.</string>
+    <string name="reminders_channel_name">Bookmarked sessions reminders</string>
+
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -46,5 +46,6 @@
 
     <string name="reminders_channel_description">Reminders display a notification 5 minutes before the start of one of your bookmarked session.</string>
     <string name="reminders_channel_name">Bookmarked sessions reminders</string>
+    <string name="reminders_text">Starting at %1$s in room %2$s</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,4 +44,7 @@
     <string name="type_quicky">Quicky</string>
     <string name="type_talk">Talk</string>
 
+    <string name="reminders_channel_description">Les rappels affichent une notification 5 minutes avant le début d’une session mise en favori.</string>
+    <string name="reminders_channel_name">Rappels des sessions favorites</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,5 +46,6 @@
 
     <string name="reminders_channel_description">Les rappels affichent une notification 5 minutes avant le début d’une session mise en favori.</string>
     <string name="reminders_channel_name">Rappels des sessions favorites</string>
+    <string name="reminders_text">Débute à %1$s en salle %2$s</string>
 
 </resources>


### PR DESCRIPTION
The main idea in this PR is to add a new feature to the application called "reminders". Reminders are quick and simple notification warning the user a bookmarked session is about to start. More precisely, it gets displayed 5 minutes prior the event. Here are some notes about the initial implementation:

  * The current implementation relies on both a `Service` and the system's `AlarmManager`.
  * I highly doubt the current implementation will work on Android O due to the new restriction on apps targeting and/or running on O. I guess I will have to disable the feature pre-O because a local implementation seems complicated to me. We should instead use push notifications.
  * Even pre-O, the current implementation misses wake-lock handling.
  * I've managed Android O notification channels but I doubt they'll be useful as I don't see a simple way to implement the feature on Android O
  * The fact the device notifies N times if N sessions are starting is known. Once again … the implementation is extremely simple.
  * The notification displays the title of the session, the time at which it stars & the room in which it will be.