### PR TITLE
Sessions sectioning

### DIFF
--- a/app/src/main/kotlin/com/gdgnantes/devfest/android/MainActivity.kt
+++ b/app/src/main/kotlin/com/gdgnantes/devfest/android/MainActivity.kt
@@ -33,6 +33,7 @@ class MainActivity : BaseActivity() {
         viewPager = findViewById<ViewPager>(R.id.view_pager)
         viewPager.adapter = adapter
         viewPager.pageMargin = resources.getDimensionPixelSize(R.dimen.spacing_medium)
+        viewPager.setPageMarginDrawable(R.drawable.spacer_medium_cloud)
 
         val tabLayout = findViewById<TabLayout>(R.id.tab_layout)
         tabLayout.setupWithViewPager(viewPager)

--- a/app/src/main/kotlin/com/gdgnantes/devfest/android/SessionsFragment.kt
+++ b/app/src/main/kotlin/com/gdgnantes/devfest/android/SessionsFragment.kt
@@ -14,6 +14,7 @@ import com.gdgnantes.devfest.android.app.BaseFragment
 import com.gdgnantes.devfest.android.format.text.DateTimeFormatter
 import com.gdgnantes.devfest.android.view.bind
 import com.gdgnantes.devfest.android.viewmodel.SessionsViewModel
+import java.util.*
 
 
 class SessionsFragment : BaseFragment() {
@@ -66,6 +67,7 @@ class SessionsFragment : BaseFragment() {
             view.setOnClickListener(onItemClickListener)
         }
 
+        val header: TextView by view.bind<TextView>(R.id.header)
         val title: TextView by view.bind<TextView>(R.id.title)
         val subtitle: TextView by view.bind<TextView>(R.id.subtitle)
         val favoriteIndicator: View by view.bind<View>(R.id.favorite_indicator)
@@ -75,6 +77,7 @@ class SessionsFragment : BaseFragment() {
             val context: Context) : RecyclerView.Adapter<SessionViewHolder>() {
 
         private val favoritesManager = BookmarkManager.from(context)
+        private val tmpCalendar = Calendar.getInstance()
 
         var items: List<SessionsViewModel.Data> = emptyList()
             set(items) {
@@ -82,8 +85,20 @@ class SessionsFragment : BaseFragment() {
                 notifyDataSetChanged()
             }
 
+        private fun getSectionId(position: Int): Int {
+            tmpCalendar.timeInMillis = items[position].session.startTimestamp.time
+            return tmpCalendar.get(Calendar.HOUR) * 100 + tmpCalendar.get(Calendar.MINUTE)
+        }
+
         override fun onBindViewHolder(holder: SessionViewHolder, position: Int) {
             val item = items[position]
+
+            if (position == 0 || getSectionId(position) != getSectionId(position - 1)) {
+                holder.header.visibility = View.VISIBLE
+                holder.header.text = DateTimeFormatter.formatHHmm(item.session.startTimestamp)
+            } else {
+                holder.header.visibility = View.GONE
+            }
 
             holder.title.text = item.session.title
 

--- a/app/src/main/kotlin/com/gdgnantes/devfest/android/SessionsFragment.kt
+++ b/app/src/main/kotlin/com/gdgnantes/devfest/android/SessionsFragment.kt
@@ -102,12 +102,12 @@ class SessionsFragment : BaseFragment() {
 
             holder.title.text = item.session.title
 
-            val subtitleParts = ArrayList<String>()
             if (item.room != null) {
-                subtitleParts.add(getString(R.string.session_subtitle, item.room.name))
+                holder.subtitle.text = getString(R.string.session_subtitle, item.room.name)
+                holder.subtitle.visibility = View.VISIBLE
+            } else {
+                holder.subtitle.visibility = View.GONE
             }
-            subtitleParts.add(DateTimeFormatter.formatHHmm(item.session.startTimestamp))
-            holder.subtitle.text = subtitleParts.joinToString(" - ")
 
             if (favoritesManager.isBookmarked(item.session.id)) {
                 holder.favoriteIndicator.visibility = View.VISIBLE

--- a/app/src/main/res/drawable/spacer_medium_cloud.xml
+++ b/app/src/main/res/drawable/spacer_medium_cloud.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <size
+        android:width="@dimen/spacing_medium"
+        android:height="@dimen/spacing_medium" />
+
+    <solid android:color="@color/cloud" />
+
+</shape>

--- a/app/src/main/res/layout/list_item_session.xml
+++ b/app/src/main/res/layout/list_item_session.xml
@@ -1,41 +1,63 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    style="@style/ListItem"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:divider="@drawable/spacer_medium"
-    android:orientation="horizontal"
-    android:showDividers="middle">
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/header"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/cloud"
+        android:clickable="true"
+        android:focusable="false"
+        android:gravity="center_vertical"
+        android:paddingBottom="@dimen/spacing_small"
+        android:paddingLeft="@dimen/spacing_medium"
+        android:paddingRight="@dimen/spacing_medium"
+        android:paddingTop="@dimen/spacing_small"
+        android:textAppearance="@style/TextAppearance.ListItem.Title"
+        tools:text="17:20" />
 
     <LinearLayout
-        android:layout_width="0dp"
+        style="@style/ListItem"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical"
-        android:layout_weight="1"
-        android:orientation="vertical">
+        android:divider="@drawable/spacer_medium"
+        android:orientation="horizontal"
+        android:showDividers="middle">
 
-        <TextView
-            android:id="@+id/title"
-            android:layout_width="match_parent"
+        <LinearLayout
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:textAppearance="@style/TextAppearance.ListItem.Title"
-            tools:text="What’s new in Android ds ds dsdsdsjndksjndkjs sdkjii ssjdkjd" />
+            android:layout_gravity="center_vertical"
+            android:layout_weight="1"
+            android:orientation="vertical">
 
-        <TextView
-            android:id="@+id/subtitle"
-            android:layout_width="match_parent"
+            <TextView
+                android:id="@+id/title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textAppearance="@style/TextAppearance.ListItem.Title"
+                tools:text="What’s new in Android" />
+
+            <TextView
+                android:id="@+id/subtitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textAppearance="@style/TextAppearance.ListItem.Subtitle"
+                tools:text="Tour Bretagne" />
+
+        </LinearLayout>
+
+        <ImageView
+            android:id="@+id/favorite_indicator"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textAppearance="@style/TextAppearance.ListItem.Subtitle"
-            tools:text="Tour Bretagne" />
+            android:layout_gravity="center_vertical"
+            android:src="@drawable/ic_bookmarked" />
 
     </LinearLayout>
-
-    <ImageView
-        android:id="@+id/favorite_indicator"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical"
-        android:src="@drawable/ic_bookmarked" />
 
 </LinearLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -12,6 +12,7 @@
     <color name="white">#ffffff</color>
     <color name="white_50p">#77ffffff</color>
 
+    <color name="cloud">#f0f0f0</color>
     <color name="gray_gull">#e7e7e7</color>
 
     <color name="falcon">#333333</color>


### PR DESCRIPTION
The current implementation is rather simple and only display a section header if the item’s position is 0 or if its start time is different from the one at `position - 1`.

A possible enhancement regarding UX would be to have sticky headers so that start time is always visible. Unfortunately, I haven’t found a simple library to do this…

Here's a screenshot of the result:

![screenshot_20170724-104849](https://user-images.githubusercontent.com/92794/28515603-8320f7a2-705e-11e7-95b7-7eba2f35be1a.png)
